### PR TITLE
fix total order panic

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -700,14 +700,9 @@ impl Helper {
             );
 
             best_players.sort_by(|a, b| {
-                if a.missing != b.missing {
-                    return b.missing.cmp(&a.missing);
-                }
-
-                match (a.info.stats, b.info.stats) {
-                    (Some(a), Some(b)) => a.cmp(&b),
-                    _ => a.info.level.cmp(&b.info.level),
-                }
+                return b.missing.cmp(&a.missing)
+                    .then(a.info.stats.cmp(&b.info.stats))
+                    .then(a.info.level.cmp(&b.info.level));
             });
 
             si.best = best_players;


### PR DESCRIPTION
Fixes total order panic introduced in sort functions with [rust 1.81](https://blog.rust-lang.org/2024/09/05/Rust-1.81.0.html#new-sort-implementations).

Example stack trace: 
```
thread 'main' panicked at library/core/src/slice/sort/shared/smallsort.rs:862:5:
user-provided comparison function does not correctly implement a total order
stack backtrace:
   0:     0x5d37239f6579 - <std::sys::backtrace::BacktraceLock::print::DisplayBacktrace as core::fmt::Display>::fmt::h2d64227312c2418a
   1:     0x5d3723a23b1b - core::fmt::write::h65428235328ec473
   2:     0x5d37239f29cf - std::io::Write::write_fmt::he9581ab6c6c3dfdb
   3:     0x5d37239f7901 - std::panicking::default_hook::{{closure}}::h651b305d818820f8
   4:     0x5d37239f75dc - std::panicking::default_hook::h2dfb7f9b6404b019
   5:     0x5d37239f7f51 - std::panicking::rust_panic_with_hook::hfd26bdc1f7a648e4
   6:     0x5d37239f7d83 - std::panicking::begin_panic_handler::{{closure}}::hd30ce3845ac37db7
   7:     0x5d37239f6a69 - std::sys::backtrace::__rust_end_short_backtrace::h95e5771bcf611f9a
   8:     0x5d37239f7a43 - rust_begin_unwind
   9:     0x5d3722e6ab32 - core::panicking::panic_fmt::h40b802d33b0c95ce
  10:     0x5d3723a25cb4 - core::slice::sort::shared::smallsort::panic_on_ord_violation::hc1ed7595fb8a668d
  11:     0x5d372303b603 - core::slice::sort::shared::smallsort::bidirectional_merge::h3d2c44dd90f48064
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/shared/smallsort.rs:841:13
  12:     0x5d372303b603 - core::slice::sort::shared::smallsort::small_sort_general_with_scratch::hec6ce7a7bad95e6d
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/shared/smallsort.rs:289:9
  13:     0x5d37230d559c - <T as core::slice::sort::shared::smallsort::StableSmallSortTypeImpl>::small_sort::hffdc3e6f10934e09
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/shared/smallsort.rs:64:9
  14:     0x5d37230d559c - core::slice::sort::stable::quicksort::quicksort::h97330b1956e467de
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/stable/quicksort.rs:27:13
  15:     0x5d3723054511 - core::slice::sort::stable::drift::create_run::h7c3b7af2a3161b30
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/stable/drift.rs:257:9
  16:     0x5d3723054511 - core::slice::sort::stable::drift::sort::h0f04dcd80f4acdfe
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/stable/drift.rs:66:17
  17:     0x5d3723045673 - core::slice::sort::stable::driftsort_main::h3c25b097c97e389c
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/stable/mod.rs:86:5
  18:     0x5d3722f7599c - core::slice::sort::stable::sort::h37ab49743927f9c0
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/slice/sort/stable/mod.rs:47:5
  19:     0x5d3722f7599c - alloc::slice::stable_sort::h0e47ee1f118e83fe
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/alloc/src/slice.rs:883:5
  20:     0x5d3722f7599c - alloc::slice::<impl [T]>::sort_by::h767ae23846ac2d71
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/alloc/src/slice.rs:289:9
  21:     0x5d3722f7599c - sf_scrapbook_helper::Helper::update_best::h2e8ed52d27929e66
                               at /home/niels/sf/sf-scrapbook-helper/src/main.rs:702:13
  22:     0x5d3722f637dc - sf_scrapbook_helper::message::<impl sf_scrapbook_helper::Helper>::handle_msg::hac11a8b7444bb695
                               at /home/niels/sf/sf-scrapbook-helper/src/message.rs:326:32
  23:     0x5d3722f2abfc - <sf_scrapbook_helper::Helper as iced::application::Application>::update::he0631f4c00653c58
                               at /home/niels/sf/sf-scrapbook-helper/src/main.rs:452:19
  24:     0x5d3722f2abfc - <iced::application::Instance<A> as iced_runtime::program::Program>::update::h32be464256625f24
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced-0.12.1/src/application.rs:227:9
  25:     0x5d3722f2abfc - iced_winit::application::update::{{closure}}::h860b53ff8ce17147
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_winit-0.12.2/src/application.rs:641:40
  26:     0x5d3722f2abfc - iced_futures::backend::native::tokio::<impl iced_futures::executor::Executor for tokio::runtime::runtime::Runtime>::enter::h0734218623ca2525
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_futures-0.12.0/src/backend/native/tokio.rs:19:9
  27:     0x5d3722f2abfc - iced_futures::runtime::Runtime<Executor,Sender,Message>::enter::hecfcf92c2337200b
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_futures-0.12.0/src/runtime.rs:51:9
  28:     0x5d3722f2abfc - iced_winit::application::update::hf1bb8f2b79635828
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_winit-0.12.2/src/application.rs:641:31
  29:     0x5d3722f2abfc - iced_winit::application::run_instance::{{closure}}::h094554cbefadf22d
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_winit-0.12.2/src/application.rs:528:21
  30:     0x5d3722f2abfc - iced_winit::application::run::{{closure}}::hb6c473aa8509385c
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_winit-0.12.2/src/application.rs:228:24
  31:     0x5d3722f2abfc - core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut::hbcd54498553f7bf7
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/ops/function.rs:294:13
  32:     0x5d3722f425fb - core::ops::function::impls::<impl core::ops::function::FnMut<A> for &mut F>::call_mut::h05f0ea5f30c9f0fb
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/ops/function.rs:294:13
  33:     0x5d3722f425fb - winit::platform_impl::platform::wayland::event_loop::EventLoop<T>::single_iteration::h27493b8947a1f245
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.15/src/platform_impl/linux/wayland/event_loop/mod.rs:519:9
  34:     0x5d3722f425fb - winit::platform_impl::platform::wayland::event_loop::EventLoop<T>::poll_events_with_timeout::h141a59fe3f56a209
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.15/src/platform_impl/linux/wayland/event_loop/mod.rs:322:9
  35:     0x5d3722f425fb - winit::platform_impl::platform::wayland::event_loop::EventLoop<T>::pump_events::h1d0c8e28d6633ff6
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.15/src/platform_impl/linux/wayland/event_loop/mod.rs:236:13
  36:     0x5d3722f4384b - winit::platform_impl::platform::wayland::event_loop::EventLoop<T>::run_on_demand::h72c6895a325d847c
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.15/src/platform_impl/linux/wayland/event_loop/mod.rs:200:19
  37:     0x5d3722f341fb - winit::platform_impl::platform::EventLoop<T>::run_on_demand::h6d153e4e905a8a61
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.15/src/platform_impl/linux/mod.rs:829:56
  38:     0x5d3722f341fb - winit::platform_impl::platform::EventLoop<T>::run::h1b3e0ffbec948c24
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.15/src/platform_impl/linux/mod.rs:822:9
  39:     0x5d3722f29313 - winit::event_loop::EventLoop<T>::run::h7dfd564786af5ab5
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/winit-0.29.15/src/event_loop.rs:249:9
  40:     0x5d3722f29313 - iced_winit::application::run::hb91872744601f779
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced_winit-0.12.2/src/application.rs:243:24
  41:     0x5d3722f7017b - iced::application::Application::run::h88adacf48da97631
                               at /home/niels/.cargo/registry/src/index.crates.io-6f17d22bba15001f/iced-0.12.1/src/application.rs:208:12
  42:     0x5d3722f7017b - sf_scrapbook_helper::main::h32871783b5e690e6
                               at /home/niels/sf/sf-scrapbook-helper/src/main.rs:126:5
  43:     0x5d3722eb0c36 - core::ops::function::FnOnce::call_once::h65bccf91f466f109
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/core/src/ops/function.rs:250:5
  44:     0x5d3722eb0c36 - std::sys::backtrace::__rust_begin_short_backtrace::h83b5525f89cad8b3
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/std/src/sys/backtrace.rs:152:18
  45:     0x5d3722fe43a2 - std::rt::lang_start::{{closure}}::hc5c8994e8dde6ff4
                               at /usr/src/debug/rust/rustc-1.81.0-src/library/std/src/rt.rs:162:18
  46:     0x5d37239e92dc - std::rt::lang_start_internal::h1adb007293efe76e
  47:     0x5d3722f7b10c - main
  48:     0x7fb4b68281ce - <unknown>
  49:     0x7fb4b682828a - __libc_start_main
  50:     0x5d3722e6b6e5 - _start
  51:                0x0 - <unknown>
```